### PR TITLE
Fetch full branch History for Merge after Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Update CHANGELOG
         id: changelog


### PR DESCRIPTION
The release CI currently doesn't merge the Changelog created automatically to develop after a release. The necessary step for merging fails due to unrelated history errors.
This is caused by the default behaviour of the "checkout" action, which only takes 1 commit and nothing else. With 'fetch-depth=0' it should fetch the complete history.