### PR TITLE
fix(search-bar): don't disable search button by adding chip

### DIFF
--- a/components/search-bar/src/search-bar.component.css
+++ b/components/search-bar/src/search-bar.component.css
@@ -54,3 +54,7 @@
 ::ng-deep .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token {
   background-color: var(--color-blue) !important;
 }
+
+::ng-deep .p-autocomplete[disabled=true] {
+  opacity: 0.8;
+}

--- a/components/search-bar/src/search-bar.component.html
+++ b/components/search-bar/src/search-bar.component.html
@@ -28,7 +28,7 @@
     </ng-template>
   </p-autoComplete>
   <button pButton pRipple #infoButton icon="pi pi-info-circle" class="p-button-help"
-    (mouseenter)="onMouseEnter(infoButton)" (mouseleave)="onMouseLeave(infoButton)" (click)="queryInfo.toggle($event)"
+    (click)="queryInfo.toggle($event)"
     [style.color]="colors.getPrimaryButtonColors().buttonInfo[0]"
     [style.background]="colors.getPrimaryButtonColors().buttonInfo[1]"
     [style.borderColor]="colors.getPrimaryButtonColors().buttonInfo[0]">
@@ -41,15 +41,15 @@
     </p-overlayPanel>
   </button>
   <button pButton pRipple #searchButton icon="pi pi-search" class="p-button-success"
-      [disabled]="searchBar.inputValue"
-      (mouseenter)="onMouseEnter(searchButton)" (mouseleave)="onMouseLeave(searchButton)" (click)="onSearchClick()"
+      [disabled]="hasInputText()"
+      (click)="onSearchClick()"
       [style.color]="colors.getPrimaryButtonColors().buttonSuccess[0]"
       [style.background]="colors.getPrimaryButtonColors().buttonSuccess[1]"
       [style.borderColor]="colors.getPrimaryButtonColors().buttonSuccess[1]" label="Search"
       i18n-label="text for the search button"></button>
 
-  <button pButton pRipple #clearButton icon="pi pi-times" class="p-button-danger" (mouseenter)="onMouseEnter(clearButton)"
-      (mouseleave)="onMouseLeave(clearButton)" (click)="onClearClick()"
+  <button pButton pRipple #clearButton icon="pi pi-times" class="p-button-danger"
+      (click)="onClearClick()"
       [style.color]="colors.getPrimaryButtonColors().buttonWarning[0]"
       [style.background]="colors.getPrimaryButtonColors().buttonWarning[1]"
       [style.borderColor]="colors.getPrimaryButtonColors().buttonWarning[1]" label="Clear"

--- a/components/search-bar/src/search-bar.component.ts
+++ b/components/search-bar/src/search-bar.component.ts
@@ -30,8 +30,6 @@ export class SearchBarComponent {
 
   suggestions: Array<{ label: string, value: string, items: Array<Condition | Operation> }> = [];
 
-  searchBarInput: any;
-
   @ViewChild(AutoComplete) searchBar!: AutoComplete
 
   constructor(
@@ -52,9 +50,18 @@ export class SearchBarComponent {
   }
 
 
+  /**
+   * Determine if there text in the searchbar text input that was not added to the query
+   * */
+  public hasInputText() {
+    if (this.searchBar == undefined
+       || this.searchBar.inputValue == undefined)
+      return false
+    return this.searchBar.inputValue.length > 0
+  }
+
   public search(event: { originalEvent: Event, query: string }) {
 
-    this.searchBarInput = event.originalEvent.target
     if (event.query.length < 3) {
       this.currentSearchTerm = undefined;
       this.suggestions = [{ label: "", value: "Search will start with 3 inserted letters ...", items: [] }];
@@ -148,7 +155,6 @@ export class SearchBarComponent {
     this.queryService.clear();
     this.searchBar.inputValue = ''
     this.currentSearchTerm = ''
-    this.searchBarInput.value = ''
   }
 
   removeCondition(condition: Condition) {
@@ -166,6 +172,8 @@ export class SearchBarComponent {
 
   suggestionSelected($event: Condition) {
     // if an operation or condition with the key exists, add the new value to its children with an OR, otherwise create a new condition
+
+    this.searchBar.inputValue = "";
 
     const existingValue = this.queryService.read($event.key);
 
@@ -218,13 +226,6 @@ export class SearchBarComponent {
    * Currently no performance issues noticeable. */
   public executeChipTransform(value: Condition | Operation): string {
     return this.chipTransform.transform(value);
-  }
-
-  public onMouseEnter(element: HTMLElement): void {
-    element.style.opacity = "0.8";
-  }
-  public onMouseLeave(element: HTMLElement): void {
-    element.style.opacity = "1";
   }
 
 }

--- a/core/src/lib/pipes/search-highlight.pipe.ts
+++ b/core/src/lib/pipes/search-highlight.pipe.ts
@@ -5,7 +5,12 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class SearchHighlightPipe implements PipeTransform {
 
-  transform(value: string, ...args: any): string{
+  transform(value: string | string[], ...args: any): string | string[]{
+    // search bar switches between string that only contains current input
+      // and array that contains all chips
+    if (typeof value === "object"
+      && value instanceof Array<string>)
+      return value
     if (!args) {
       return value;
     }


### PR DESCRIPTION
Adding a chip from search bar resulted in the search button not beeing activated. New implementation will disable button only while unadded input exists.