### PR TITLE
refactor: added option to don't show specific diagrams

### DIFF
--- a/core/src/lib/model/result-renderer.ts
+++ b/core/src/lib/model/result-renderer.ts
@@ -64,6 +64,7 @@ export class ResultRenderer {
   ];
   public readonly showNegotiationButton: boolean = false;
   public readonly showOn: Array<string> = [];
+  public readonly dontShowOn: Array<string> = [];
 
   constructor(
     title: string,
@@ -84,6 +85,7 @@ export class ResultRenderer {
       hoverColors?: string[],
       showNegotiationButton?: boolean
       showOn?: Array<string>
+      dontShowOn?: Array<string>
     } = { },
   ) {
     this.title = title;
@@ -117,5 +119,7 @@ export class ResultRenderer {
       this.showNegotiationButton = options.showNegotiationButton
     if(options.showOn != undefined)
       this.showOn = options.showOn
+    if(options.dontShowOn != undefined)
+      this.dontShowOn = options.dontShowOn
   }
 }


### PR DESCRIPTION
The former implementation from #40 only allowed to differentiate between an empty query and a query with one specific criteria. For the use case of showing more diagrams on consented patients the previous implementation was not sufficiant, as selecting any other criteria without the consent criteria resulted in the ui only displaying diagrams that are missing the showOn option.
This issue is solved by adding a second option "dontShowOn", which allows to specify diagrams that should disappear then a specific criteria is added to the search. The dontShowOn option has higher priority than the showOn option.